### PR TITLE
Automate publishing to GNOME Extensions

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -1,0 +1,70 @@
+name: Publish to GNOME Extensions
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    name: Package and publish extension
+    runs-on: ubuntu-latest
+    env:
+      EXTENSION_DIR: lockscreen@sri.ramkrishna.me
+      DIST_DIR: dist
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install GNOME Extensions tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gnome-shell gnome-shell-extension-prefs gnome-session-bin python3-pip jq
+          pip3 install --user gnome-extensions-cli
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          gnome-extensions version
+          gext --version
+
+      - name: Determine version from metadata
+        id: metadata
+        run: |
+          VERSION=$(jq -r '.version' "${EXTENSION_DIR}/metadata.json")
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+            echo "::error::Unable to read version from metadata.json"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Package extension
+        run: |
+          mkdir -p "$DIST_DIR"
+          gnome-extensions pack "$EXTENSION_DIR" --out-dir "$DIST_DIR" --force
+
+      - name: Publish extension to extensions.gnome.org
+        env:
+          GNOME_EXTENSIONS_API_KEY: ${{ secrets.GNOME_EXTENSIONS_API_KEY }}
+        run: |
+          if [ -z "$GNOME_EXTENSIONS_API_KEY" ]; then
+            echo "::warning::GNOME_EXTENSIONS_API_KEY secret not configured. Skipping publish step."
+            exit 0
+          fi
+
+          ARCHIVE=$(ls "$DIST_DIR"/*.shell-extension.zip)
+          if [ -z "$ARCHIVE" ]; then
+            echo "::error::Extension archive not found"
+            exit 1
+          fi
+
+          python3 scripts/publish_to_gnome_extensions.py \
+            --archive "$ARCHIVE" \
+            --api-key "$GNOME_EXTENSIONS_API_KEY" \
+            --uuid $(jq -r '.uuid' "${EXTENSION_DIR}/metadata.json") \
+            --version "${{ steps.metadata.outputs.version }}"
+
+      - name: Upload built artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: shell-extension
+          path: ${{ env.DIST_DIR }}
+          if-no-files-found: warn

--- a/README
+++ b/README
@@ -1,3 +1,23 @@
 My extensions for GNOME 3
-
 License is: GPL2 or later
+
+## Automatisierte Veröffentlichung
+
+Dieses Repository enthält einen GitHub Actions Workflow, der die Erweiterung
+verpackt und – sobald ein gültiger API-Schlüssel hinterlegt wurde – automatisch
+auf extensions.gnome.org veröffentlicht. Um die Aktualisierung zu aktivieren,
+füge in den Repository-Einstellungen das Secret `GNOME_EXTENSIONS_API_KEY`
+mit deinem persönlichen API-Schlüssel hinzu. Wenn ein Tag nach dem Schema
+`v*` erstellt oder der Workflow manuell ausgelöst wird, passiert Folgendes:
+
+1. Abhängigkeiten (`gnome-shell`, `gnome-extensions-cli` usw.) werden
+   installiert.
+2. Die Erweiterung aus `lockscreen@sri.ramkrishna.me/` wird mit
+   `gnome-extensions pack` zu einem Zip-Archiv gebaut.
+3. Das Archiv wird mit Hilfe des Skripts
+   `scripts/publish_to_gnome_extensions.py` über `gext publish` zur Plattform
+   hochgeladen.
+4. Das gebaute Paket wird als Workflow-Artefakt zur Verfügung gestellt.
+
+So bleibt die Erweiterung auf extensions.gnome.org automatisch auf dem
+aktuellen Stand, ohne dass lokal ein Zip-Archiv erzeugt werden muss.

--- a/scripts/publish_to_gnome_extensions.py
+++ b/scripts/publish_to_gnome_extensions.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Helper script to upload the packaged extension to extensions.gnome.org.
+
+The official API for publishing extensions is not publicly documented, but the
+community maintained ``gnome-extensions-cli`` project exposes a stable command
+line interface that can be used in automation environments.  This wrapper keeps
+our workflow declarative and allows us to validate user input before delegating
+
+the heavy lifting to ``gext`` (``gnome-extensions-cli``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def ensure_executable(name: str) -> str:
+    """Ensure that *name* is available on ``PATH`` and return its absolute path."""
+    executable = shutil.which(name)
+    if not executable:
+        raise FileNotFoundError(
+            f"Required executable '{name}' was not found on PATH."
+        )
+    return executable
+
+
+def publish_extension(archive: Path, uuid: str, api_key: str, version: str) -> None:
+    """Publish *archive* to extensions.gnome.org using ``gext``."""
+    gext = ensure_executable("gext")
+
+    subprocess.run([gext, "--help"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    print(f"Publishing {archive.name} for {uuid} (version {version}) via gext…", flush=True)
+
+    publish_cmd = [
+        gext,
+        "publish",
+        str(archive),
+        "--api-key",
+        api_key,
+    ]
+
+    result = subprocess.run(publish_cmd, check=True, capture_output=True, text=True)
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--archive", required=True, type=Path, help="Path to the packaged extension archive")
+    parser.add_argument("--uuid", required=True, help="Extension UUID")
+    parser.add_argument("--api-key", required=True, help="API key for extensions.gnome.org")
+    parser.add_argument("--version", required=True, help="Extension version")
+
+    args = parser.parse_args(argv)
+
+    archive: Path = args.archive
+    if not archive.exists():
+        parser.error(f"Archive '{archive}' does not exist")
+
+    api_key = args.api_key.strip()
+    if not api_key:
+        parser.error("The API key must not be empty")
+
+    publish_extension(archive=archive, uuid=args.uuid, api_key=api_key, version=args.version)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that packages the lock screen extension and publishes updates when tagged or triggered manually
- introduce a helper script that wraps gext for publishing and update the README with setup instructions

## Testing
- python3 -m compileall scripts/publish_to_gnome_extensions.py

------
https://chatgpt.com/codex/tasks/task_e_68e3a4875468832c9ddf1ae93480d6ef