### PR TITLE
Modernize lock screen extension metadata and button

### DIFF
--- a/lockscreen@sri.ramkrishna.me/extension.js
+++ b/lockscreen@sri.ramkrishna.me/extension.js
@@ -27,18 +27,22 @@ import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 
 import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 
-export default class LockScreenExtension extends Extension {
-    constructor(metadata) {
-        super(metadata);
-    }
+const STATUS_AREA_ID = 'lockscreen-button';
 
+export default class LockScreenExtension extends Extension {
     enable() {
+        if (this._button)
+            return;
+
         this._button = new LockScreenButton();
-        Main.panel.addToStatusArea(this.metadata.uuid, this._button);
+        Main.panel.addToStatusArea(STATUS_AREA_ID, this._button);
     }
 
     disable() {
-        this._button?.destroy();
+        if (!this._button)
+            return;
+
+        this._button.destroy();
         this._button = null;
     }
 }
@@ -49,7 +53,10 @@ class LockScreenButton extends PanelMenu.Button {
     }
 
     constructor() {
-        super(0.0, null, true);
+        super(0.0, 'Lock Screen', true);
+
+        this.accessible_name = 'Lock Screen';
+        this.add_style_class_name('panel-button');
 
         this._icon = new St.Icon ({
             icon_name: 'changes-prevent-symbolic',
@@ -58,7 +65,7 @@ class LockScreenButton extends PanelMenu.Button {
 
         this.add_child(this._icon);
 
-        this.connect('button-press-event', this.#lockScreen);
+        this.connect('clicked', () => this.#lockScreen());
     }
 
     #lockScreen() {

--- a/lockscreen@sri.ramkrishna.me/metadata.json
+++ b/lockscreen@sri.ramkrishna.me/metadata.json
@@ -1,10 +1,13 @@
 {
-  "description": "Add lock icon to the panel and lock the screen instead of using ctrl-alt-l", 
-  "name": "Lock Screen", 
+  "uuid": "lockscreen@sri.ramkrishna.me",
+  "name": "Lock Screen",
+  "description": "Add a lock icon to the top bar and lock the screen without a keyboard shortcut.",
+  "version": 16,
   "shell-version": [
-    "45", "46", "47", "48"
-  ], 
-  "url": "https://github.com/sramkrishna/gnome3-extensions", 
-  "uuid": "lockscreen@sri.ramkrishna.me", 
-  "version": 15
+    "45",
+    "46",
+    "47",
+    "48"
+  ],
+  "url": "https://github.com/sramkrishna/gnome3-extensions"
 }


### PR DESCRIPTION
## Summary
- update the extension metadata to keep the UUID directory in sync, refresh the description, and bump the release version
- guard enable/disable to avoid duplicate status area buttons and add an explicit status area identifier
- improve the panel button's accessibility by setting a name and relying on the clicked signal

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3ab900bcc832c9e69912920d83317