### PR TITLE
Automate publishing to GNOME Extensions

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -1,0 +1,70 @@
+name: Publish to GNOME Extensions
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    name: Package and publish extension
+    runs-on: ubuntu-latest
+    env:
+      EXTENSION_DIR: lockscreen@sri.ramkrishna.me
+      DIST_DIR: dist
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install GNOME Extensions tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gnome-shell gnome-shell-extension-prefs gnome-session-bin python3-pip jq
+          pip3 install --user gnome-extensions-cli
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          gnome-extensions version
+          gext --version
+
+      - name: Determine version from metadata
+        id: metadata
+        run: |
+          VERSION=$(jq -r '.version' "${EXTENSION_DIR}/metadata.json")
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+            echo "::error::Unable to read version from metadata.json"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Package extension
+        run: |
+          mkdir -p "$DIST_DIR"
+          gnome-extensions pack "$EXTENSION_DIR" --out-dir "$DIST_DIR" --force
+
+      - name: Publish extension to extensions.gnome.org
+        env:
+          GNOME_EXTENSIONS_API_KEY: ${{ secrets.GNOME_EXTENSIONS_API_KEY }}
+        run: |
+          if [ -z "$GNOME_EXTENSIONS_API_KEY" ]; then
+            echo "::warning::GNOME_EXTENSIONS_API_KEY secret not configured. Skipping publish step."
+            exit 0
+          fi
+
+          ARCHIVE=$(ls "$DIST_DIR"/*.shell-extension.zip)
+          if [ -z "$ARCHIVE" ]; then
+            echo "::error::Extension archive not found"
+            exit 1
+          fi
+
+          python3 scripts/publish_to_gnome_extensions.py \
+            --archive "$ARCHIVE" \
+            --api-key "$GNOME_EXTENSIONS_API_KEY" \
+            --uuid $(jq -r '.uuid' "${EXTENSION_DIR}/metadata.json") \
+            --version "${{ steps.metadata.outputs.version }}"
+
+      - name: Upload built artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: shell-extension
+          path: ${{ env.DIST_DIR }}
+          if-no-files-found: warn

--- a/README
+++ b/README
@@ -1,3 +1,21 @@
 My extensions for GNOME 3
+License: GPL2 or later
 
-License is: GPL2 or later
+## Automated publishing
+
+This repository ships a GitHub Actions workflow that packages the extension and,
+once a valid API key has been configured, automatically publishes it to
+extensions.gnome.org. To enable automated updates, add the secret
+`GNOME_EXTENSIONS_API_KEY` with your personal API key in the repository
+settings. When a tag matching the `v*` pattern is created or the workflow is
+triggered manually, it performs the following steps:
+
+1. Install the required dependencies (`gnome-shell`, `gnome-extensions-cli`, etc.).
+2. Package the extension from `lockscreen@sri.ramkrishna.me/` using
+   `gnome-extensions pack` to produce a zip archive.
+3. Upload the archive to extensions.gnome.org via `gext publish` through the
+   helper script `scripts/publish_to_gnome_extensions.py`.
+4. Attach the built package as a workflow artifact.
+
+This keeps the extension on extensions.gnome.org up to date automatically
+without needing to generate a zip archive locally.

--- a/scripts/publish_to_gnome_extensions.py
+++ b/scripts/publish_to_gnome_extensions.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Helper script to upload the packaged extension to extensions.gnome.org.
+
+The official API for publishing extensions is not publicly documented, but the
+community maintained ``gnome-extensions-cli`` project exposes a stable command
+line interface that can be used in automation environments.  This wrapper keeps
+our workflow declarative and allows us to validate user input before delegating
+
+the heavy lifting to ``gext`` (``gnome-extensions-cli``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def ensure_executable(name: str) -> str:
+    """Ensure that *name* is available on ``PATH`` and return its absolute path."""
+    executable = shutil.which(name)
+    if not executable:
+        raise FileNotFoundError(
+            f"Required executable '{name}' was not found on PATH."
+        )
+    return executable
+
+
+def publish_extension(archive: Path, uuid: str, api_key: str, version: str) -> None:
+    """Publish *archive* to extensions.gnome.org using ``gext``."""
+    gext = ensure_executable("gext")
+
+    subprocess.run([gext, "--help"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    print(f"Publishing {archive.name} for {uuid} (version {version}) via gext…", flush=True)
+
+    publish_cmd = [
+        gext,
+        "publish",
+        str(archive),
+        "--api-key",
+        api_key,
+    ]
+
+    result = subprocess.run(publish_cmd, check=True, capture_output=True, text=True)
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--archive", required=True, type=Path, help="Path to the packaged extension archive")
+    parser.add_argument("--uuid", required=True, help="Extension UUID")
+    parser.add_argument("--api-key", required=True, help="API key for extensions.gnome.org")
+    parser.add_argument("--version", required=True, help="Extension version")
+
+    args = parser.parse_args(argv)
+
+    archive: Path = args.archive
+    if not archive.exists():
+        parser.error(f"Archive '{archive}' does not exist")
+
+    api_key = args.api_key.strip()
+    if not api_key:
+        parser.error("The API key must not be empty")
+
+    publish_extension(archive=archive, uuid=args.uuid, api_key=api_key, version=args.version)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that packages the lock screen extension and publishes updates when tagged or triggered manually
- introduce a helper script that wraps gext for publishing and update the README with setup instructions in English

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68e3a4875468832c9ddf1ae93480d6ef